### PR TITLE
Several minor fixes to Python intro notebook

### DIFF
--- a/python/00-python-intro-w-solutions.ipynb
+++ b/python/00-python-intro-w-solutions.ipynb
@@ -112,7 +112,7 @@
     "b = a\n",
     "a = 2\n",
     "## What is b?\n",
-    "print b"
+    "print(b)"
    ]
   },
   {
@@ -332,14 +332,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Exercise 1 - Conversion\n",
+    "### Exercise 1 - Conversion\n",
     "\n",
     "Throughout this lesson, we will successively build towards a program that will calculate the\n",
     "variance of some measurements,  in this case `Height in Metres`.  The first thing we want to do is convert from an antiquated measurement system.\n",
     "\n",
     "To change inches into metres we use the following equation (conversion factor is rounded)\n",
     "\n",
-    "##$metre = \\frac{inches}{39}$\n",
+    "## $metre = \\frac{inches}{39}$\n",
     "\n",
     "1. Create a variable for the conversion factor, called `inches_in_metre`.\n",
     "1. Create a variable (`inches`) for your height in inches, as inaccurately as you want.\n",
@@ -1053,7 +1053,7 @@
     "\n",
     "As a reminder, **sample variance** is the calculated from the sum of squared differences of each observation from the mean:\n",
     "\n",
-    "###$variance = \\frac{\\Sigma{(x-mean)^2}}{n-1}$\n",
+    "### $variance = \\frac{\\Sigma{(x-mean)^2}}{n-1}$\n",
     "\n",
     "where **mean** is the mean of our observations, **x** is each individual observation, and **n** is the number of observations.\n",
     "\n",

--- a/python/00-python-intro.ipynb
+++ b/python/00-python-intro.ipynb
@@ -112,7 +112,7 @@
     "b = a\n",
     "a = 2\n",
     "## What is b?\n",
-    "print b"
+    "print(b)"
    ]
   },
   {
@@ -332,14 +332,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Exercise 1 - Conversion\n",
+    "### Exercise 1 - Conversion\n",
     "\n",
     "Throughout this lesson, we will successively build towards a program that will calculate the\n",
     "variance of some measurements,  in this case `Height in Metres`.  The first thing we want to do is convert from an antiquated measurement system.\n",
     "\n",
     "To change inches into metres we use the following equation (conversion factor is rounded)\n",
     "\n",
-    "##$metre = \\frac{inches}{39}$\n",
+    "## $metre = \\frac{inches}{39}$\n",
     "\n",
     "1. Create a variable for the conversion factor, called `inches_in_metre`.\n",
     "1. Create a variable (`inches`) for your height in inches, as inaccurately as you want.\n",
@@ -1000,7 +1000,7 @@
     "\n",
     "As a reminder, **sample variance** is the calculated from the sum of squared differences of each observation from the mean:\n",
     "\n",
-    "###$variance = \\frac{\\Sigma{(x-mean)^2}}{n-1}$\n",
+    "### $variance = \\frac{\\Sigma{(x-mean)^2}}{n-1}$\n",
     "\n",
     "where **mean** is the mean of our observations, **x** is each individual observation, and **n** is the number of observations.\n",
     "\n",


### PR DESCRIPTION
Hi! I was grabbing a copy of this lesson for a training session I'm doing at Mozfest, and I noticed a few little bits that needed fixing. :-)

One 'print' hadn't been converted to Python 3 syntax, and Markdown headings now need a space after the `##` to be rendered in recent versions of the notebook.
